### PR TITLE
fix query validator concurrency issue by remove private static

### DIFF
--- a/src/MinimalCqrs/Validation/ValidationExtensions.cs
+++ b/src/MinimalCqrs/Validation/ValidationExtensions.cs
@@ -4,8 +4,6 @@ namespace MinimalCqrs;
 
 internal static class ValidationExtensions
 {
-    private static IValidator? _validator = null;
-
     public static async Task<IDictionary<string, string[]>?> ExecuteValidationAsync<TResponse>(IHandlerMessage<TResponse> message)
     {
         var messageType = message.GetType();
@@ -30,8 +28,5 @@ internal static class ValidationExtensions
     }
 
     private static IValidator GetValidator(Type validatorType)
-    {
-        _validator = (IValidator)Conf.ServiceResolver.CreateSingleton(validatorType);
-        return _validator;
-    }
+        => (IValidator)Conf.ServiceResolver.CreateSingleton(validatorType);
 }


### PR DESCRIPTION
Storing the validator in a single, shared static variable is not thread safe. If two different requests come in at the exact same time requiring two different validators (e.g., `UserValidator `and `OrderValidator`), they will both call `GetValidator`. One thread will overwrite the _validator variable right as the other thread is trying to use it. This will lead to unpredictable behavior, such as passing a User object into an `OrderValidator`, which will cause a crash.

This version avoid this issue
```
private static IValidator GetValidator(Type validatorType)
    => (IValidator)Conf.ServiceResolver.CreateSingleton(validatorType);
```

Also DI is handling the caching of the object so we don't need to store.

